### PR TITLE
include css preprocessors extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ var defaultGlobs = [
   '**/*.{md,markdown}',
   '**/*.js',
   '**/*.html',
-  '**/*.css',
+  '**/*.{css,sass,scss,less,styl}',
 
   //> exclude node_modules
   '!**/node_modules/**'


### PR DESCRIPTION
This is needed to be able to build styleguides with the most popular css preprocessors.